### PR TITLE
Replaced the removed /srs_stages endpoint from beta with the new /spaced_repetition_systems one

### DIFF
--- a/src/main/java/com/wanikani/api/v2/WaniKaniClient.java
+++ b/src/main/java/com/wanikani/api/v2/WaniKaniClient.java
@@ -5,8 +5,12 @@ import com.wanikani.api.v2.model.*;
 import com.wanikani.api.v2.request.AssignmentsRequest;
 import com.wanikani.api.v2.request.ReviewStatisticsRequest;
 import com.wanikani.api.v2.request.ReviewsRequest;
+import com.wanikani.api.v2.request.SpacedRepetitionSystemsRequest;
 import com.wanikani.api.v2.request.SubjectsRequest;
 
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 import static com.wanikani.api.v2.Constants.BASE_URL;
@@ -64,11 +68,22 @@ public class WaniKaniClient {
         return transformer.getListData(resource);
     }
 
-    public List<SrsStage> getSrsStages() {
-        String response = client.request(BASE_URL + "/srs_stages");
-        Resource<List<SrsStage>> resource = jsonUtils.fromJson(response, new TypeReference<Resource<List<SrsStage>>>() {
+    /**
+     * Get all Spaced Repetition Systems matching the given query.
+     * See <a href="https://docs.api.wanikani.com/20170710/#spaced-repetition-systems">WaniKani docs</a>
+     */
+    public List<SpacedRepetitionSystem> getSpacedRepetitionSystems(SpacedRepetitionSystemsRequest request) {
+        String response = client.request(BASE_URL + "/spaced_repetition_systems" + request.getQueryString());
+        Resource<List<Resource<SpacedRepetitionSystem>>> resource = jsonUtils.fromJson(response, new TypeReference<Resource<List<Resource<SpacedRepetitionSystem>>>>() {
         });
-        return transformer.getData(resource);
+        return transformer.getListData(resource);
+    }
+
+    /**
+     * Convenience method that gets all Spaced Repetition Systems.
+     */
+    public List<SpacedRepetitionSystem> getSpacedRepetitionSystems() {
+        return getSpacedRepetitionSystems(SpacedRepetitionSystemsRequest.builder().build());
     }
 
     public List<Reset> getResets() {

--- a/src/main/java/com/wanikani/api/v2/WaniKaniClient.java
+++ b/src/main/java/com/wanikani/api/v2/WaniKaniClient.java
@@ -8,9 +8,6 @@ import com.wanikani.api.v2.request.ReviewsRequest;
 import com.wanikani.api.v2.request.SpacedRepetitionSystemsRequest;
 import com.wanikani.api.v2.request.SubjectsRequest;
 
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import static com.wanikani.api.v2.Constants.BASE_URL;

--- a/src/main/java/com/wanikani/api/v2/model/IntervalUnit.java
+++ b/src/main/java/com/wanikani/api/v2/model/IntervalUnit.java
@@ -1,0 +1,37 @@
+package com.wanikani.api.v2.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public enum IntervalUnit {
+    SECONDS("seconds");
+
+    private final String name;
+
+    IntervalUnit(String name) {
+        this.name = name;
+    }
+
+    public static IntervalUnit findByName(String name) {
+        return Arrays
+                .stream(values())
+                .filter(t -> t.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static class Deserializer extends JsonDeserializer<IntervalUnit> {
+        @Override
+        public IntervalUnit deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            return findByName(p.getValueAsString());
+        }
+    }
+}

--- a/src/main/java/com/wanikani/api/v2/model/SpacedRepetitionSystem.java
+++ b/src/main/java/com/wanikani/api/v2/model/SpacedRepetitionSystem.java
@@ -1,0 +1,80 @@
+package com.wanikani.api.v2.model;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class SpacedRepetitionSystem {
+    private Date createdAt;
+    private String name;
+    private String description;
+    private int unlockingStagePosition;
+    private int startingStagePosition;
+    private int passingStagePosition;
+    private int burningStagePosition;
+    private List<SrsStage> stages = new ArrayList<>();
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getUnlockingStagePosition() {
+        return unlockingStagePosition;
+    }
+
+    public void setUnlockingStagePosition(int unlockingStagePosition) {
+        this.unlockingStagePosition = unlockingStagePosition;
+    }
+
+    public int getStartingStagePosition() {
+        return startingStagePosition;
+    }
+
+    public void setStartingStagePosition(int startingStagePosition) {
+        this.startingStagePosition = startingStagePosition;
+    }
+
+    public int getPassingStagePosition() {
+        return passingStagePosition;
+    }
+
+    public void setPassingStagePosition(int passingStagePosition) {
+        this.passingStagePosition = passingStagePosition;
+    }
+
+    public int getBurningStagePosition() {
+        return burningStagePosition;
+    }
+
+    public void setBurningStagePosition(int burningStagePosition) {
+        this.burningStagePosition = burningStagePosition;
+    }
+
+    public List<SrsStage> getStages() {
+        return stages;
+    }
+
+    public void setStages(List<SrsStage> stages) {
+        this.stages = stages;
+    }
+}

--- a/src/main/java/com/wanikani/api/v2/model/SrsStage.java
+++ b/src/main/java/com/wanikani/api/v2/model/SrsStage.java
@@ -1,41 +1,35 @@
 package com.wanikani.api.v2.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 public class SrsStage {
 
-    private Integer srsStage;
-    private String srsStageName;
-    private Long interval;
-    private Long acceleratedInterval;
+    private Integer interval;
+    private int position;
+    @JsonDeserialize(using = IntervalUnit.Deserializer.class)
+    private IntervalUnit intervalUnit;
 
-    public Integer getSrsStage() {
-        return srsStage;
-    }
-
-    public void setSrsStage(Integer srsStage) {
-        this.srsStage = srsStage;
-    }
-
-    public String getSrsStageName() {
-        return srsStageName;
-    }
-
-    public void setSrsStageName(String srsStageName) {
-        this.srsStageName = srsStageName;
-    }
-
-    public Long getInterval() {
+    public Integer getInterval() {
         return interval;
     }
 
-    public void setInterval(Long interval) {
+    public void setInterval(Integer interval) {
         this.interval = interval;
     }
 
-    public Long getAcceleratedInterval() {
-        return acceleratedInterval;
+    public int getPosition() {
+        return position;
     }
 
-    public void setAcceleratedInterval(Long acceleratedInterval) {
-        this.acceleratedInterval = acceleratedInterval;
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public IntervalUnit getIntervalUnit() {
+        return intervalUnit;
+    }
+
+    public void setIntervalUnit(IntervalUnit intervalUnit) {
+        this.intervalUnit = intervalUnit;
     }
 }

--- a/src/main/java/com/wanikani/api/v2/request/SpacedRepetitionSystemsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/SpacedRepetitionSystemsRequest.java
@@ -1,0 +1,53 @@
+package com.wanikani.api.v2.request;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.wanikani.api.v2.request.QueryStringUtils.appendDate;
+import static com.wanikani.api.v2.request.QueryStringUtils.appendList;
+
+public class SpacedRepetitionSystemsRequest implements Request {
+
+    private final String queryString;
+
+    public SpacedRepetitionSystemsRequest(String queryString) {
+        this.queryString = queryString;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getQueryString() {
+        return queryString;
+    }
+
+    public static class Builder {
+        private List<Long> ids = new ArrayList<>();
+        private Date updatedAfter;
+
+        public Builder ids(List<Long> ids) {
+            this.ids = ids;
+            return this;
+        }
+
+        public Builder ids(long... ids) {
+            return ids(Arrays.stream(ids).boxed().collect(Collectors.toList()));
+        }
+
+        public Builder updatedAfter(Date updatedAfter) {
+            this.updatedAfter = updatedAfter;
+            return this;
+        }
+
+        public SpacedRepetitionSystemsRequest build() {
+            StringBuilder queryString = new StringBuilder();
+            appendDate(queryString, "updated_after", updatedAfter);
+            appendList(queryString, "ids", ids);
+            return new SpacedRepetitionSystemsRequest(queryString.toString());
+        }
+    }
+}

--- a/src/test/java/com/wanikani/api/v2/util/DateUtilsTest.java
+++ b/src/test/java/com/wanikani/api/v2/util/DateUtilsTest.java
@@ -16,7 +16,7 @@ public class DateUtilsTest {
         calendar.setTime(date);
         assertEquals(10, calendar.get(Calendar.MONTH));
         assertEquals(22, calendar.get(Calendar.DAY_OF_MONTH));
-        assertEquals(7, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(12, calendar.get(Calendar.HOUR_OF_DAY));
         assertEquals(52, calendar.get(Calendar.MINUTE));
         assertEquals(38, calendar.get(Calendar.SECOND));
         assertEquals(0, calendar.get(Calendar.MILLISECOND));


### PR DESCRIPTION
I didn't see what the API used to be, but it looks like the stages now form part of a larger "SRS System". There are 2 systems: one's normal and one's "accelerated", and the stages are a bit different for each.

https://docs.api.wanikani.com/20170710/#spaced-repetition-systems

One of the tests was failing. I think it might be timezone sensitive. That would explain the difference of 5 hours if you're in the US. I'm going to suggest replacing the j.u.Date with java.time anyway, so could fix it properly with that.

Not sure how you feel about the class names here. SpacedRepetitionSystemsRequest ends up being a bit of a mouthful. 