### PR TITLE
Migrate java.util.Date to java.time.ZonedDateTime

### DIFF
--- a/src/main/java/com/wanikani/api/v2/ObjectMapperFactory.java
+++ b/src/main/java/com/wanikani/api/v2/ObjectMapperFactory.java
@@ -1,15 +1,34 @@
 package com.wanikani.api.v2;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.wanikani.api.v2.util.DateUtils;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
 
 class ObjectMapperFactory {
 
     ObjectMapper getInstance() {
+        SimpleModule dateModule = new SimpleModule();
+        dateModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
+
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        mapper.registerModule(dateModule);
         return mapper;
+    }
+
+    private static class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+        @Override
+        public LocalDateTime deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
+            return DateUtils.getApiDate(p.getValueAsString());
+        }
     }
 }

--- a/src/main/java/com/wanikani/api/v2/ObjectMapperFactory.java
+++ b/src/main/java/com/wanikani/api/v2/ObjectMapperFactory.java
@@ -10,13 +10,13 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.wanikani.api.v2.util.DateUtils;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 class ObjectMapperFactory {
 
     ObjectMapper getInstance() {
         SimpleModule dateModule = new SimpleModule();
-        dateModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
+        dateModule.addDeserializer(ZonedDateTime.class, new ZonedDateTimeDeserializer());
 
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -25,9 +25,9 @@ class ObjectMapperFactory {
         return mapper;
     }
 
-    private static class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+    private static class ZonedDateTimeDeserializer extends JsonDeserializer<ZonedDateTime> {
         @Override
-        public LocalDateTime deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
+        public ZonedDateTime deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
             return DateUtils.getApiDate(p.getValueAsString());
         }
     }

--- a/src/main/java/com/wanikani/api/v2/model/Assignment.java
+++ b/src/main/java/com/wanikani/api/v2/model/Assignment.java
@@ -1,17 +1,17 @@
 package com.wanikani.api.v2.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 public class Assignment implements Identifiable {
 
     private Long id;
-    private Date createdAt;
-    private Date unlockedAt;
-    private Date startedAt;
-    private Date passedAt;
-    private Date burnedAt;
-    private Date availableAt;
-    private Date resurrectedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime unlockedAt;
+    private LocalDateTime startedAt;
+    private LocalDateTime passedAt;
+    private LocalDateTime burnedAt;
+    private LocalDateTime availableAt;
+    private LocalDateTime resurrectedAt;
     private Long subjectId;
     private String subjectType;
     private Integer srsStage;
@@ -30,59 +30,59 @@ public class Assignment implements Identifiable {
         this.id = id;
     }
 
-    public Date getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(Date createdAt) {
+    public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
-    public Date getUnlockedAt() {
+    public LocalDateTime getUnlockedAt() {
         return unlockedAt;
     }
 
-    public void setUnlockedAt(Date unlockedAt) {
+    public void setUnlockedAt(LocalDateTime unlockedAt) {
         this.unlockedAt = unlockedAt;
     }
 
-    public Date getStartedAt() {
+    public LocalDateTime getStartedAt() {
         return startedAt;
     }
 
-    public void setStartedAt(Date startedAt) {
+    public void setStartedAt(LocalDateTime startedAt) {
         this.startedAt = startedAt;
     }
 
-    public Date getPassedAt() {
+    public LocalDateTime getPassedAt() {
         return passedAt;
     }
 
-    public void setPassedAt(Date passedAt) {
+    public void setPassedAt(LocalDateTime passedAt) {
         this.passedAt = passedAt;
     }
 
-    public Date getBurnedAt() {
+    public LocalDateTime getBurnedAt() {
         return burnedAt;
     }
 
-    public void setBurnedAt(Date burnedAt) {
+    public void setBurnedAt(LocalDateTime burnedAt) {
         this.burnedAt = burnedAt;
     }
 
-    public Date getAvailableAt() {
+    public LocalDateTime getAvailableAt() {
         return availableAt;
     }
 
-    public void setAvailableAt(Date availableAt) {
+    public void setAvailableAt(LocalDateTime availableAt) {
         this.availableAt = availableAt;
     }
 
-    public Date getResurrectedAt() {
+    public LocalDateTime getResurrectedAt() {
         return resurrectedAt;
     }
 
-    public void setResurrectedAt(Date resurrectedAt) {
+    public void setResurrectedAt(LocalDateTime resurrectedAt) {
         this.resurrectedAt = resurrectedAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/Assignment.java
+++ b/src/main/java/com/wanikani/api/v2/model/Assignment.java
@@ -1,17 +1,17 @@
 package com.wanikani.api.v2.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class Assignment implements Identifiable {
 
     private Long id;
-    private LocalDateTime createdAt;
-    private LocalDateTime unlockedAt;
-    private LocalDateTime startedAt;
-    private LocalDateTime passedAt;
-    private LocalDateTime burnedAt;
-    private LocalDateTime availableAt;
-    private LocalDateTime resurrectedAt;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime unlockedAt;
+    private ZonedDateTime startedAt;
+    private ZonedDateTime passedAt;
+    private ZonedDateTime burnedAt;
+    private ZonedDateTime availableAt;
+    private ZonedDateTime resurrectedAt;
     private Long subjectId;
     private String subjectType;
     private Integer srsStage;
@@ -30,59 +30,59 @@ public class Assignment implements Identifiable {
         this.id = id;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public ZonedDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(ZonedDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
-    public LocalDateTime getUnlockedAt() {
+    public ZonedDateTime getUnlockedAt() {
         return unlockedAt;
     }
 
-    public void setUnlockedAt(LocalDateTime unlockedAt) {
+    public void setUnlockedAt(ZonedDateTime unlockedAt) {
         this.unlockedAt = unlockedAt;
     }
 
-    public LocalDateTime getStartedAt() {
+    public ZonedDateTime getStartedAt() {
         return startedAt;
     }
 
-    public void setStartedAt(LocalDateTime startedAt) {
+    public void setStartedAt(ZonedDateTime startedAt) {
         this.startedAt = startedAt;
     }
 
-    public LocalDateTime getPassedAt() {
+    public ZonedDateTime getPassedAt() {
         return passedAt;
     }
 
-    public void setPassedAt(LocalDateTime passedAt) {
+    public void setPassedAt(ZonedDateTime passedAt) {
         this.passedAt = passedAt;
     }
 
-    public LocalDateTime getBurnedAt() {
+    public ZonedDateTime getBurnedAt() {
         return burnedAt;
     }
 
-    public void setBurnedAt(LocalDateTime burnedAt) {
+    public void setBurnedAt(ZonedDateTime burnedAt) {
         this.burnedAt = burnedAt;
     }
 
-    public LocalDateTime getAvailableAt() {
+    public ZonedDateTime getAvailableAt() {
         return availableAt;
     }
 
-    public void setAvailableAt(LocalDateTime availableAt) {
+    public void setAvailableAt(ZonedDateTime availableAt) {
         this.availableAt = availableAt;
     }
 
-    public LocalDateTime getResurrectedAt() {
+    public ZonedDateTime getResurrectedAt() {
         return resurrectedAt;
     }
 
-    public void setResurrectedAt(LocalDateTime resurrectedAt) {
+    public void setResurrectedAt(ZonedDateTime resurrectedAt) {
         this.resurrectedAt = resurrectedAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/LevelProgression.java
+++ b/src/main/java/com/wanikani/api/v2/model/LevelProgression.java
@@ -1,16 +1,16 @@
 package com.wanikani.api.v2.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 public class LevelProgression implements Identifiable {
 
     private Long id;
-    private Date createdAt;
-    private Date unlockedAt;
-    private Date startedAt;
-    private Date passedAt;
-    private Date completedAt;
-    private Date abandonedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime unlockedAt;
+    private LocalDateTime startedAt;
+    private LocalDateTime passedAt;
+    private LocalDateTime completedAt;
+    private LocalDateTime abandonedAt;
     private Integer level;
 
     @Override
@@ -23,51 +23,51 @@ public class LevelProgression implements Identifiable {
         this.id = id;
     }
 
-    public Date getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(Date createdAt) {
+    public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
-    public Date getUnlockedAt() {
+    public LocalDateTime getUnlockedAt() {
         return unlockedAt;
     }
 
-    public void setUnlockedAt(Date unlockedAt) {
+    public void setUnlockedAt(LocalDateTime unlockedAt) {
         this.unlockedAt = unlockedAt;
     }
 
-    public Date getStartedAt() {
+    public LocalDateTime getStartedAt() {
         return startedAt;
     }
 
-    public void setStartedAt(Date startedAt) {
+    public void setStartedAt(LocalDateTime startedAt) {
         this.startedAt = startedAt;
     }
 
-    public Date getPassedAt() {
+    public LocalDateTime getPassedAt() {
         return passedAt;
     }
 
-    public void setPassedAt(Date passedAt) {
+    public void setPassedAt(LocalDateTime passedAt) {
         this.passedAt = passedAt;
     }
 
-    public Date getCompletedAt() {
+    public LocalDateTime getCompletedAt() {
         return completedAt;
     }
 
-    public void setCompletedAt(Date completedAt) {
+    public void setCompletedAt(LocalDateTime completedAt) {
         this.completedAt = completedAt;
     }
 
-    public Date getAbandonedAt() {
+    public LocalDateTime getAbandonedAt() {
         return abandonedAt;
     }
 
-    public void setAbandonedAt(Date abandonedAt) {
+    public void setAbandonedAt(LocalDateTime abandonedAt) {
         this.abandonedAt = abandonedAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/LevelProgression.java
+++ b/src/main/java/com/wanikani/api/v2/model/LevelProgression.java
@@ -1,16 +1,16 @@
 package com.wanikani.api.v2.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class LevelProgression implements Identifiable {
 
     private Long id;
-    private LocalDateTime createdAt;
-    private LocalDateTime unlockedAt;
-    private LocalDateTime startedAt;
-    private LocalDateTime passedAt;
-    private LocalDateTime completedAt;
-    private LocalDateTime abandonedAt;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime unlockedAt;
+    private ZonedDateTime startedAt;
+    private ZonedDateTime passedAt;
+    private ZonedDateTime completedAt;
+    private ZonedDateTime abandonedAt;
     private Integer level;
 
     @Override
@@ -23,51 +23,51 @@ public class LevelProgression implements Identifiable {
         this.id = id;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public ZonedDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(ZonedDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
-    public LocalDateTime getUnlockedAt() {
+    public ZonedDateTime getUnlockedAt() {
         return unlockedAt;
     }
 
-    public void setUnlockedAt(LocalDateTime unlockedAt) {
+    public void setUnlockedAt(ZonedDateTime unlockedAt) {
         this.unlockedAt = unlockedAt;
     }
 
-    public LocalDateTime getStartedAt() {
+    public ZonedDateTime getStartedAt() {
         return startedAt;
     }
 
-    public void setStartedAt(LocalDateTime startedAt) {
+    public void setStartedAt(ZonedDateTime startedAt) {
         this.startedAt = startedAt;
     }
 
-    public LocalDateTime getPassedAt() {
+    public ZonedDateTime getPassedAt() {
         return passedAt;
     }
 
-    public void setPassedAt(LocalDateTime passedAt) {
+    public void setPassedAt(ZonedDateTime passedAt) {
         this.passedAt = passedAt;
     }
 
-    public LocalDateTime getCompletedAt() {
+    public ZonedDateTime getCompletedAt() {
         return completedAt;
     }
 
-    public void setCompletedAt(LocalDateTime completedAt) {
+    public void setCompletedAt(ZonedDateTime completedAt) {
         this.completedAt = completedAt;
     }
 
-    public LocalDateTime getAbandonedAt() {
+    public ZonedDateTime getAbandonedAt() {
         return abandonedAt;
     }
 
-    public void setAbandonedAt(LocalDateTime abandonedAt) {
+    public void setAbandonedAt(ZonedDateTime abandonedAt) {
         this.abandonedAt = abandonedAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/Reset.java
+++ b/src/main/java/com/wanikani/api/v2/model/Reset.java
@@ -1,12 +1,12 @@
 package com.wanikani.api.v2.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 public class Reset implements Identifiable {
 
     private Long id;
-    private Date createdAt;
-    private Date confirmedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime confirmedAt;
     private Integer originalLevel;
     private Integer targetLevel;
 
@@ -20,19 +20,19 @@ public class Reset implements Identifiable {
         this.id = id;
     }
 
-    public Date getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(Date createdAt) {
+    public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
-    public Date getConfirmedAt() {
+    public LocalDateTime getConfirmedAt() {
         return confirmedAt;
     }
 
-    public void setConfirmedAt(Date confirmedAt) {
+    public void setConfirmedAt(LocalDateTime confirmedAt) {
         this.confirmedAt = confirmedAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/Reset.java
+++ b/src/main/java/com/wanikani/api/v2/model/Reset.java
@@ -1,12 +1,12 @@
 package com.wanikani.api.v2.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class Reset implements Identifiable {
 
     private Long id;
-    private LocalDateTime createdAt;
-    private LocalDateTime confirmedAt;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime confirmedAt;
     private Integer originalLevel;
     private Integer targetLevel;
 
@@ -20,19 +20,19 @@ public class Reset implements Identifiable {
         this.id = id;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public ZonedDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(ZonedDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
-    public LocalDateTime getConfirmedAt() {
+    public ZonedDateTime getConfirmedAt() {
         return confirmedAt;
     }
 
-    public void setConfirmedAt(LocalDateTime confirmedAt) {
+    public void setConfirmedAt(ZonedDateTime confirmedAt) {
         this.confirmedAt = confirmedAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/Resource.java
+++ b/src/main/java/com/wanikani/api/v2/model/Resource.java
@@ -1,13 +1,13 @@
 package com.wanikani.api.v2.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 public class Resource<T> {
 
     private Long id;
     private String object;
     private String url;
-    private Date dataUpdatedAt;
+    private LocalDateTime dataUpdatedAt;
     private Integer totalCount;
     private Pages pages;
     private T data;
@@ -36,11 +36,11 @@ public class Resource<T> {
         this.url = url;
     }
 
-    public Date getDataUpdatedAt() {
+    public LocalDateTime getDataUpdatedAt() {
         return dataUpdatedAt;
     }
 
-    public void setDataUpdatedAt(Date dataUpdatedAt) {
+    public void setDataUpdatedAt(LocalDateTime dataUpdatedAt) {
         this.dataUpdatedAt = dataUpdatedAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/Resource.java
+++ b/src/main/java/com/wanikani/api/v2/model/Resource.java
@@ -1,13 +1,13 @@
 package com.wanikani.api.v2.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class Resource<T> {
 
     private Long id;
     private String object;
     private String url;
-    private LocalDateTime dataUpdatedAt;
+    private ZonedDateTime dataUpdatedAt;
     private Integer totalCount;
     private Pages pages;
     private T data;
@@ -36,11 +36,11 @@ public class Resource<T> {
         this.url = url;
     }
 
-    public LocalDateTime getDataUpdatedAt() {
+    public ZonedDateTime getDataUpdatedAt() {
         return dataUpdatedAt;
     }
 
-    public void setDataUpdatedAt(LocalDateTime dataUpdatedAt) {
+    public void setDataUpdatedAt(ZonedDateTime dataUpdatedAt) {
         this.dataUpdatedAt = dataUpdatedAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/Review.java
+++ b/src/main/java/com/wanikani/api/v2/model/Review.java
@@ -1,12 +1,12 @@
 package com.wanikani.api.v2.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 public class Review implements Identifiable {
 
     private Long id;
-    private Date createdAt;
+    private LocalDateTime createdAt;
     private Long assignmentId;
     private Integer subjectId;
     private Integer startingSrsStage;
@@ -26,11 +26,11 @@ public class Review implements Identifiable {
         this.id = id;
     }
 
-    public Date getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(Date createdAt) {
+    public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/Review.java
+++ b/src/main/java/com/wanikani/api/v2/model/Review.java
@@ -1,12 +1,12 @@
 package com.wanikani.api.v2.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 public class Review implements Identifiable {
 
     private Long id;
-    private LocalDateTime createdAt;
+    private ZonedDateTime createdAt;
     private Long assignmentId;
     private Integer subjectId;
     private Integer startingSrsStage;
@@ -26,11 +26,11 @@ public class Review implements Identifiable {
         this.id = id;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public ZonedDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(ZonedDateTime createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/ReviewStatistic.java
+++ b/src/main/java/com/wanikani/api/v2/model/ReviewStatistic.java
@@ -1,10 +1,10 @@
 package com.wanikani.api.v2.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 public class ReviewStatistic implements Identifiable {
     private Long id;
-    private Date createdAt;
+    private LocalDateTime createdAt;
     private Long subjectId;
     private String subjectType;
     private Integer meaningCorrect;
@@ -28,11 +28,11 @@ public class ReviewStatistic implements Identifiable {
         this.id = id;
     }
 
-    public Date getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(Date createdAt) {
+    public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/ReviewStatistic.java
+++ b/src/main/java/com/wanikani/api/v2/model/ReviewStatistic.java
@@ -1,10 +1,10 @@
 package com.wanikani.api.v2.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class ReviewStatistic implements Identifiable {
     private Long id;
-    private LocalDateTime createdAt;
+    private ZonedDateTime createdAt;
     private Long subjectId;
     private String subjectType;
     private Integer meaningCorrect;
@@ -28,11 +28,11 @@ public class ReviewStatistic implements Identifiable {
         this.id = id;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public ZonedDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(ZonedDateTime createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/SpacedRepetitionSystem.java
+++ b/src/main/java/com/wanikani/api/v2/model/SpacedRepetitionSystem.java
@@ -1,7 +1,7 @@
 package com.wanikani.api.v2.model;
 
-import java.util.ArrayList;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public class SpacedRepetitionSystem {

--- a/src/main/java/com/wanikani/api/v2/model/SpacedRepetitionSystem.java
+++ b/src/main/java/com/wanikani/api/v2/model/SpacedRepetitionSystem.java
@@ -1,11 +1,11 @@
 package com.wanikani.api.v2.model;
 
 import java.util.ArrayList;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public class SpacedRepetitionSystem {
-    private LocalDateTime createdAt;
+    private ZonedDateTime createdAt;
     private String name;
     private String description;
     private int unlockingStagePosition;
@@ -14,11 +14,11 @@ public class SpacedRepetitionSystem {
     private int burningStagePosition;
     private List<SrsStage> stages = new ArrayList<>();
 
-    public LocalDateTime getCreatedAt() {
+    public ZonedDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(ZonedDateTime createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/SpacedRepetitionSystem.java
+++ b/src/main/java/com/wanikani/api/v2/model/SpacedRepetitionSystem.java
@@ -1,11 +1,11 @@
 package com.wanikani.api.v2.model;
 
 import java.util.ArrayList;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class SpacedRepetitionSystem {
-    private Date createdAt;
+    private LocalDateTime createdAt;
     private String name;
     private String description;
     private int unlockingStagePosition;
@@ -14,11 +14,11 @@ public class SpacedRepetitionSystem {
     private int burningStagePosition;
     private List<SrsStage> stages = new ArrayList<>();
 
-    public Date getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(Date createdAt) {
+    public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/StudyMaterial.java
+++ b/src/main/java/com/wanikani/api/v2/model/StudyMaterial.java
@@ -3,12 +3,12 @@ package com.wanikani.api.v2.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.ArrayList;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class StudyMaterial {
 
-    private Date createdAt;
+    private LocalDateTime createdAt;
     private boolean hidden;
     private String meaningNote;
     private List<String> meaningSynonyms = new ArrayList<>();
@@ -17,11 +17,11 @@ public class StudyMaterial {
     @JsonDeserialize(using = SubjectType.Deserializer.class)
     private SubjectType subjectType;
 
-    public Date getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(Date createdAt) {
+    public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/StudyMaterial.java
+++ b/src/main/java/com/wanikani/api/v2/model/StudyMaterial.java
@@ -2,8 +2,8 @@ package com.wanikani.api.v2.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import java.util.ArrayList;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public class StudyMaterial {

--- a/src/main/java/com/wanikani/api/v2/model/StudyMaterial.java
+++ b/src/main/java/com/wanikani/api/v2/model/StudyMaterial.java
@@ -3,12 +3,12 @@ package com.wanikani.api.v2.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.ArrayList;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public class StudyMaterial {
 
-    private LocalDateTime createdAt;
+    private ZonedDateTime createdAt;
     private boolean hidden;
     private String meaningNote;
     private List<String> meaningSynonyms = new ArrayList<>();
@@ -17,11 +17,11 @@ public class StudyMaterial {
     @JsonDeserialize(using = SubjectType.Deserializer.class)
     private SubjectType subjectType;
 
-    public LocalDateTime getCreatedAt() {
+    public ZonedDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(ZonedDateTime createdAt) {
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/Subject.java
+++ b/src/main/java/com/wanikani/api/v2/model/Subject.java
@@ -1,6 +1,6 @@
 package com.wanikani.api.v2.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -8,7 +8,7 @@ public class Subject implements Identifiable {
 
     private Long id;
     private Integer level;
-    private LocalDateTime createdAt;
+    private ZonedDateTime createdAt;
     private String characters;
     private List<CharacterImage> characterImages;
     private List<Meaning> meanings;
@@ -16,7 +16,7 @@ public class Subject implements Identifiable {
     private String slug;
     private String documentUrl;
     private SubjectType type;
-    private LocalDateTime hiddenAt;
+    private ZonedDateTime hiddenAt;
     private List<String> partsOfSpeech;
     private List<Long> componentSubjectIds;
     private List<Long> amalgamationSubjectIds;
@@ -39,11 +39,11 @@ public class Subject implements Identifiable {
         this.level = level;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public ZonedDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(ZonedDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
@@ -103,11 +103,11 @@ public class Subject implements Identifiable {
         this.readings = readings;
     }
 
-    public LocalDateTime getHiddenAt() {
+    public ZonedDateTime getHiddenAt() {
         return hiddenAt;
     }
 
-    public void setHiddenAt(LocalDateTime hiddenAt) {
+    public void setHiddenAt(ZonedDateTime hiddenAt) {
         this.hiddenAt = hiddenAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/Subject.java
+++ b/src/main/java/com/wanikani/api/v2/model/Subject.java
@@ -1,6 +1,6 @@
 package com.wanikani.api.v2.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -8,7 +8,7 @@ public class Subject implements Identifiable {
 
     private Long id;
     private Integer level;
-    private Date createdAt;
+    private LocalDateTime createdAt;
     private String characters;
     private List<CharacterImage> characterImages;
     private List<Meaning> meanings;
@@ -16,7 +16,7 @@ public class Subject implements Identifiable {
     private String slug;
     private String documentUrl;
     private SubjectType type;
-    private Date hiddenAt;
+    private LocalDateTime hiddenAt;
     private List<String> partsOfSpeech;
     private List<Long> componentSubjectIds;
     private List<Long> amalgamationSubjectIds;
@@ -39,11 +39,11 @@ public class Subject implements Identifiable {
         this.level = level;
     }
 
-    public Date getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(Date createdAt) {
+    public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
@@ -103,11 +103,11 @@ public class Subject implements Identifiable {
         this.readings = readings;
     }
 
-    public Date getHiddenAt() {
+    public LocalDateTime getHiddenAt() {
         return hiddenAt;
     }
 
-    public void setHiddenAt(Date hiddenAt) {
+    public void setHiddenAt(LocalDateTime hiddenAt) {
         this.hiddenAt = hiddenAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/Summary.java
+++ b/src/main/java/com/wanikani/api/v2/model/Summary.java
@@ -1,19 +1,19 @@
 package com.wanikani.api.v2.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public class Summary {
 
-    private LocalDateTime nextReviewsAt;
+    private ZonedDateTime nextReviewsAt;
     private List<SummaryReview> reviews;
     private List<SummaryLesson> lessons;
 
-    public LocalDateTime getNextReviewsAt() {
+    public ZonedDateTime getNextReviewsAt() {
         return nextReviewsAt;
     }
 
-    public void setNextReviewsAt(LocalDateTime nextReviewsAt) {
+    public void setNextReviewsAt(ZonedDateTime nextReviewsAt) {
         this.nextReviewsAt = nextReviewsAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/Summary.java
+++ b/src/main/java/com/wanikani/api/v2/model/Summary.java
@@ -1,19 +1,19 @@
 package com.wanikani.api.v2.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class Summary {
 
-    private Date nextReviewsAt;
+    private LocalDateTime nextReviewsAt;
     private List<SummaryReview> reviews;
     private List<SummaryLesson> lessons;
 
-    public Date getNextReviewsAt() {
+    public LocalDateTime getNextReviewsAt() {
         return nextReviewsAt;
     }
 
-    public void setNextReviewsAt(Date nextReviewsAt) {
+    public void setNextReviewsAt(LocalDateTime nextReviewsAt) {
         this.nextReviewsAt = nextReviewsAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/SummaryLesson.java
+++ b/src/main/java/com/wanikani/api/v2/model/SummaryLesson.java
@@ -1,18 +1,18 @@
 package com.wanikani.api.v2.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class SummaryLesson {
 
-    private Date availableAt;
+    private LocalDateTime availableAt;
     private List<Integer> subjectIds;
 
-    public Date getAvailableAt() {
+    public LocalDateTime getAvailableAt() {
         return availableAt;
     }
 
-    public void setAvailableAt(Date availableAt) {
+    public void setAvailableAt(LocalDateTime availableAt) {
         this.availableAt = availableAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/SummaryLesson.java
+++ b/src/main/java/com/wanikani/api/v2/model/SummaryLesson.java
@@ -1,18 +1,18 @@
 package com.wanikani.api.v2.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public class SummaryLesson {
 
-    private LocalDateTime availableAt;
+    private ZonedDateTime availableAt;
     private List<Integer> subjectIds;
 
-    public LocalDateTime getAvailableAt() {
+    public ZonedDateTime getAvailableAt() {
         return availableAt;
     }
 
-    public void setAvailableAt(LocalDateTime availableAt) {
+    public void setAvailableAt(ZonedDateTime availableAt) {
         this.availableAt = availableAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/SummaryReview.java
+++ b/src/main/java/com/wanikani/api/v2/model/SummaryReview.java
@@ -1,18 +1,18 @@
 package com.wanikani.api.v2.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public class SummaryReview {
 
-    private LocalDateTime availableAt;
+    private ZonedDateTime availableAt;
     private List<Integer> subjectIds;
 
-    public LocalDateTime getAvailableAt() {
+    public ZonedDateTime getAvailableAt() {
         return availableAt;
     }
 
-    public void setAvailableAt(LocalDateTime availableAt) {
+    public void setAvailableAt(ZonedDateTime availableAt) {
         this.availableAt = availableAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/SummaryReview.java
+++ b/src/main/java/com/wanikani/api/v2/model/SummaryReview.java
@@ -1,18 +1,18 @@
 package com.wanikani.api.v2.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class SummaryReview {
 
-    private Date availableAt;
+    private LocalDateTime availableAt;
     private List<Integer> subjectIds;
 
-    public Date getAvailableAt() {
+    public LocalDateTime getAvailableAt() {
         return availableAt;
     }
 
-    public void setAvailableAt(Date availableAt) {
+    public void setAvailableAt(LocalDateTime availableAt) {
         this.availableAt = availableAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/User.java
+++ b/src/main/java/com/wanikani/api/v2/model/User.java
@@ -1,15 +1,15 @@
 package com.wanikani.api.v2.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class User {
 
     private String id;
     private String username;
     private Integer level;
-    private LocalDateTime startedAt;
+    private ZonedDateTime startedAt;
     private boolean subscribed;
-    private LocalDateTime currentVacationStartedAt;
+    private ZonedDateTime currentVacationStartedAt;
     private Integer maxLevelGrantedBySubscription;
 
     public String getId() {
@@ -36,11 +36,11 @@ public class User {
         this.level = level;
     }
 
-    public LocalDateTime getStartedAt() {
+    public ZonedDateTime getStartedAt() {
         return startedAt;
     }
 
-    public void setStartedAt(LocalDateTime startedAt) {
+    public void setStartedAt(ZonedDateTime startedAt) {
         this.startedAt = startedAt;
     }
 
@@ -52,11 +52,11 @@ public class User {
         this.subscribed = subscribed;
     }
 
-    public LocalDateTime getCurrentVacationStartedAt() {
+    public ZonedDateTime getCurrentVacationStartedAt() {
         return currentVacationStartedAt;
     }
 
-    public void setCurrentVacationStartedAt(LocalDateTime currentVacationStartedAt) {
+    public void setCurrentVacationStartedAt(ZonedDateTime currentVacationStartedAt) {
         this.currentVacationStartedAt = currentVacationStartedAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/model/User.java
+++ b/src/main/java/com/wanikani/api/v2/model/User.java
@@ -1,15 +1,15 @@
 package com.wanikani.api.v2.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 public class User {
 
     private String id;
     private String username;
     private Integer level;
-    private Date startedAt;
+    private LocalDateTime startedAt;
     private boolean subscribed;
-    private Date currentVacationStartedAt;
+    private LocalDateTime currentVacationStartedAt;
     private Integer maxLevelGrantedBySubscription;
 
     public String getId() {
@@ -36,11 +36,11 @@ public class User {
         this.level = level;
     }
 
-    public Date getStartedAt() {
+    public LocalDateTime getStartedAt() {
         return startedAt;
     }
 
-    public void setStartedAt(Date startedAt) {
+    public void setStartedAt(LocalDateTime startedAt) {
         this.startedAt = startedAt;
     }
 
@@ -52,11 +52,11 @@ public class User {
         this.subscribed = subscribed;
     }
 
-    public Date getCurrentVacationStartedAt() {
+    public LocalDateTime getCurrentVacationStartedAt() {
         return currentVacationStartedAt;
     }
 
-    public void setCurrentVacationStartedAt(Date currentVacationStartedAt) {
+    public void setCurrentVacationStartedAt(LocalDateTime currentVacationStartedAt) {
         this.currentVacationStartedAt = currentVacationStartedAt;
     }
 

--- a/src/main/java/com/wanikani/api/v2/request/AssignmentsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/AssignmentsRequest.java
@@ -3,6 +3,7 @@ package com.wanikani.api.v2.request;
 import com.wanikani.api.v2.model.SubjectType;
 
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -70,8 +71,12 @@ public class AssignmentsRequest implements Request {
             return this;
         }
 
-        public Builder availableBefore(Instant instant) {
-            return availableBefore(instant.atZone(ZoneOffset.UTC));
+        public Builder availableBefore(Instant availableBefore) {
+            return availableBefore(availableBefore.atZone(ZoneOffset.UTC));
+        }
+
+        public Builder availableBefore(OffsetDateTime availableBefore) {
+            return availableBefore(availableBefore.toZonedDateTime());
         }
 
         public Builder availableAfter(ZonedDateTime availableAfter) {
@@ -79,8 +84,12 @@ public class AssignmentsRequest implements Request {
             return this;
         }
 
-        public Builder availableAfter(Instant instant) {
-            return availableAfter(instant.atZone(ZoneOffset.UTC));
+        public Builder availableAfter(Instant availableAfter) {
+            return availableAfter(availableAfter.atZone(ZoneOffset.UTC));
+        }
+
+        public Builder availableAfter(OffsetDateTime availableAfter) {
+            return availableBefore(availableAfter.toZonedDateTime());
         }
 
         public Builder createdAt(ZonedDateTime createdAt) {
@@ -88,8 +97,12 @@ public class AssignmentsRequest implements Request {
             return this;
         }
 
-        public Builder createdAt(Instant instant) {
-            return createdAt(instant.atZone(ZoneOffset.UTC));
+        public Builder createdAt(Instant createdAt) {
+            return createdAt(createdAt.atZone(ZoneOffset.UTC));
+        }
+
+        public Builder createdAt(OffsetDateTime createdAt) {
+            return createdAt(createdAt.toZonedDateTime());
         }
 
         public Builder srsStages(List<Integer> srsStages) {

--- a/src/main/java/com/wanikani/api/v2/request/AssignmentsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/AssignmentsRequest.java
@@ -2,9 +2,11 @@ package com.wanikani.api.v2.request;
 
 import com.wanikani.api.v2.model.SubjectType;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.time.ZonedDateTime;
 import java.util.List;
 
 import static com.wanikani.api.v2.request.QueryStringUtils.append;
@@ -28,7 +30,7 @@ public class AssignmentsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder {
+    public static class Builder extends BaseBuilder<AssignmentsRequest, Builder> {
 
         private List<Integer> ids = new ArrayList<>();
         private List<Integer> subjectIds = new ArrayList<>();
@@ -45,7 +47,6 @@ public class AssignmentsRequest implements Request {
         private ZonedDateTime availableBefore;
         private ZonedDateTime availableAfter;
         private Long pageAfterId;
-        private ZonedDateTime updatedAfter;
 
         public Builder ids(Integer... ids) {
             this.ids = Arrays.asList(ids);
@@ -76,19 +77,26 @@ public class AssignmentsRequest implements Request {
             return this;
         }
 
+        public Builder availableBefore(Instant instant) {
+            return availableBefore(instant.atZone(ZoneOffset.UTC));
+        }
+
         public Builder availableAfter(ZonedDateTime availableAfter) {
             this.availableAfter = availableAfter;
             return this;
         }
 
-        public Builder updatedAfter(ZonedDateTime updatedAfter) {
-            this.updatedAfter = updatedAfter;
-            return this;
+        public Builder availableAfter(Instant instant) {
+            return availableAfter(instant.atZone(ZoneOffset.UTC));
         }
 
         public Builder createdAt(ZonedDateTime createdAt) {
             this.createdAt = createdAt;
             return this;
+        }
+
+        public Builder createdAt(Instant instant) {
+            return createdAt(instant.atZone(ZoneOffset.UTC));
         }
 
         public Builder pageAfterId(Long id) {
@@ -135,13 +143,13 @@ public class AssignmentsRequest implements Request {
             return this;
         }
 
+        @Override
         public AssignmentsRequest build() {
-            StringBuilder queryString = new StringBuilder();
+            StringBuilder queryString = super.queryString();
             appendList(queryString, "ids", ids);
             appendList(queryString, "subject_ids", subjectIds);
             appendList(queryString, "levels", levels);
             appendList(queryString, "subject_types", subjectTypes);
-            appendDate(queryString, "updated_after", updatedAfter);
             appendDate(queryString, "created_at", createdAt);
             appendDate(queryString, "available_before", availableBefore);
             appendDate(queryString, "available_after", availableAfter);

--- a/src/main/java/com/wanikani/api/v2/request/AssignmentsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/AssignmentsRequest.java
@@ -4,7 +4,7 @@ import com.wanikani.api.v2.model.SubjectType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.wanikani.api.v2.request.QueryStringUtils.append;
@@ -41,11 +41,11 @@ public class AssignmentsRequest implements Request {
         private Boolean burned;
         private Boolean resurrected;
         private Boolean hidden;
-        private Date createdAt;
-        private Date availableBefore;
-        private Date availableAfter;
+        private LocalDateTime createdAt;
+        private LocalDateTime availableBefore;
+        private LocalDateTime availableAfter;
         private Long pageAfterId;
-        private Date updatedAfter;
+        private LocalDateTime updatedAfter;
 
         public Builder ids(Integer... ids) {
             this.ids = Arrays.asList(ids);
@@ -71,22 +71,22 @@ public class AssignmentsRequest implements Request {
             return subjectTypes(Arrays.asList(subjectTypes));
         }
 
-        public Builder availableBefore(Date availableBefore) {
+        public Builder availableBefore(LocalDateTime availableBefore) {
             this.availableBefore = availableBefore;
             return this;
         }
 
-        public Builder availableAfter(Date availableAfter) {
+        public Builder availableAfter(LocalDateTime availableAfter) {
             this.availableAfter = availableAfter;
             return this;
         }
 
-        public Builder updatedAfter(Date updatedAfter) {
+        public Builder updatedAfter(LocalDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }
 
-        public Builder createdAt(Date createdAt) {
+        public Builder createdAt(LocalDateTime createdAt) {
             this.createdAt = createdAt;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/AssignmentsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/AssignmentsRequest.java
@@ -30,9 +30,8 @@ public class AssignmentsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder extends BaseBuilder<AssignmentsRequest, Builder> {
+    public static class Builder extends CollectionBuilder<AssignmentsRequest, Builder> {
 
-        private List<Integer> ids = new ArrayList<>();
         private List<Integer> subjectIds = new ArrayList<>();
         private List<String> subjectTypes = new ArrayList<>();
         private List<Integer> levels = new ArrayList<>();
@@ -46,12 +45,6 @@ public class AssignmentsRequest implements Request {
         private ZonedDateTime createdAt;
         private ZonedDateTime availableBefore;
         private ZonedDateTime availableAfter;
-        private Long pageAfterId;
-
-        public Builder ids(Integer... ids) {
-            this.ids = Arrays.asList(ids);
-            return this;
-        }
 
         public Builder subjectIds(Integer... ids) {
             this.subjectIds = Arrays.asList(ids);
@@ -99,11 +92,6 @@ public class AssignmentsRequest implements Request {
             return createdAt(instant.atZone(ZoneOffset.UTC));
         }
 
-        public Builder pageAfterId(Long id) {
-            this.pageAfterId = id;
-            return this;
-        }
-
         public Builder srsStages(List<Integer> srsStages) {
             this.srsStages = srsStages;
             return this;
@@ -146,7 +134,6 @@ public class AssignmentsRequest implements Request {
         @Override
         public AssignmentsRequest build() {
             StringBuilder queryString = super.queryString();
-            appendList(queryString, "ids", ids);
             appendList(queryString, "subject_ids", subjectIds);
             appendList(queryString, "levels", levels);
             appendList(queryString, "subject_types", subjectTypes);
@@ -154,7 +141,6 @@ public class AssignmentsRequest implements Request {
             appendDate(queryString, "available_before", availableBefore);
             appendDate(queryString, "available_after", availableAfter);
             appendList(queryString, "srs_stages", srsStages);
-            append(queryString, "page_after_id", pageAfterId);
             append(queryString, "unlocked", unlocked);
             append(queryString, "started", started);
             append(queryString, "passed", passed);

--- a/src/main/java/com/wanikani/api/v2/request/AssignmentsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/AssignmentsRequest.java
@@ -4,7 +4,7 @@ import com.wanikani.api.v2.model.SubjectType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import static com.wanikani.api.v2.request.QueryStringUtils.append;
@@ -41,11 +41,11 @@ public class AssignmentsRequest implements Request {
         private Boolean burned;
         private Boolean resurrected;
         private Boolean hidden;
-        private LocalDateTime createdAt;
-        private LocalDateTime availableBefore;
-        private LocalDateTime availableAfter;
+        private ZonedDateTime createdAt;
+        private ZonedDateTime availableBefore;
+        private ZonedDateTime availableAfter;
         private Long pageAfterId;
-        private LocalDateTime updatedAfter;
+        private ZonedDateTime updatedAfter;
 
         public Builder ids(Integer... ids) {
             this.ids = Arrays.asList(ids);
@@ -71,22 +71,22 @@ public class AssignmentsRequest implements Request {
             return subjectTypes(Arrays.asList(subjectTypes));
         }
 
-        public Builder availableBefore(LocalDateTime availableBefore) {
+        public Builder availableBefore(ZonedDateTime availableBefore) {
             this.availableBefore = availableBefore;
             return this;
         }
 
-        public Builder availableAfter(LocalDateTime availableAfter) {
+        public Builder availableAfter(ZonedDateTime availableAfter) {
             this.availableAfter = availableAfter;
             return this;
         }
 
-        public Builder updatedAfter(LocalDateTime updatedAfter) {
+        public Builder updatedAfter(ZonedDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }
 
-        public Builder createdAt(LocalDateTime createdAt) {
+        public Builder createdAt(ZonedDateTime createdAt) {
             this.createdAt = createdAt;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/BaseBuilder.java
+++ b/src/main/java/com/wanikani/api/v2/request/BaseBuilder.java
@@ -1,7 +1,6 @@
 package com.wanikani.api.v2.request;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;

--- a/src/main/java/com/wanikani/api/v2/request/BaseBuilder.java
+++ b/src/main/java/com/wanikani/api/v2/request/BaseBuilder.java
@@ -10,6 +10,7 @@ abstract class BaseBuilder<T, B extends BaseBuilder<T, B>> {
 
     ZonedDateTime updatedAfter;
 
+    @SuppressWarnings("unchecked")
     public B updatedAfter(ZonedDateTime updatedAfter) {
         this.updatedAfter = updatedAfter;
         return (B) this;

--- a/src/main/java/com/wanikani/api/v2/request/BaseBuilder.java
+++ b/src/main/java/com/wanikani/api/v2/request/BaseBuilder.java
@@ -1,6 +1,8 @@
 package com.wanikani.api.v2.request;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
@@ -16,8 +18,12 @@ abstract class BaseBuilder<T, B extends BaseBuilder<T, B>> {
         return (B) this;
     }
 
-    public B updatedAfter(Instant instant) {
-        return updatedAfter(instant.atZone(ZoneOffset.UTC));
+    public B updatedAfter(Instant updatedAfter) {
+        return updatedAfter(updatedAfter.atZone(ZoneOffset.UTC));
+    }
+
+    public B updatedAfter(OffsetDateTime updatedAfter) {
+        return updatedAfter(updatedAfter.toZonedDateTime());
     }
 
     StringBuilder queryString() {

--- a/src/main/java/com/wanikani/api/v2/request/BaseBuilder.java
+++ b/src/main/java/com/wanikani/api/v2/request/BaseBuilder.java
@@ -1,0 +1,29 @@
+package com.wanikani.api.v2.request;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static com.wanikani.api.v2.request.QueryStringUtils.appendDate;
+
+abstract class BaseBuilder<T, B extends BaseBuilder<T, B>> {
+
+    ZonedDateTime updatedAfter;
+
+    public B updatedAfter(ZonedDateTime updatedAfter) {
+        this.updatedAfter = updatedAfter;
+        return (B) this;
+    }
+
+    public B updatedAfter(Instant instant) {
+        return updatedAfter(instant.atZone(ZoneOffset.UTC));
+    }
+
+    StringBuilder queryString() {
+        StringBuilder sb = new StringBuilder();
+        appendDate(sb, "updated_after", updatedAfter);
+        return sb;
+    }
+
+    public abstract T build();
+}

--- a/src/main/java/com/wanikani/api/v2/request/CollectionBuilder.java
+++ b/src/main/java/com/wanikani/api/v2/request/CollectionBuilder.java
@@ -1,0 +1,47 @@
+package com.wanikani.api.v2.request;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.wanikani.api.v2.request.QueryStringUtils.append;
+import static com.wanikani.api.v2.request.QueryStringUtils.appendList;
+
+abstract class CollectionBuilder<T, B extends CollectionBuilder<T, B>> extends BaseBuilder<T, B> {
+
+    private List<Long> ids = new ArrayList<>();
+    private Long pageAfterId;
+
+    public B ids(Long... ids) {
+        return ids(Arrays.asList(ids));
+    }
+
+    @SuppressWarnings("unchecked")
+    public B ids(List<Long> ids) {
+        this.ids = ids;
+        return (B) this;
+    }
+
+    public B ids(long... ids) {
+        return ids(Arrays.stream(ids).boxed().collect(Collectors.toList()));
+    }
+
+    public B pageAfterId(Integer id) {
+        return pageAfterId(id.longValue());
+    }
+
+    @SuppressWarnings("unchecked")
+    public B pageAfterId(Long id) {
+        this.pageAfterId = id;
+        return (B) this;
+    }
+
+    @Override
+    StringBuilder queryString() {
+        StringBuilder queryString = super.queryString();
+        appendList(queryString, "ids", ids);
+        append(queryString, "page_after_id", pageAfterId);
+        return queryString;
+    }
+}

--- a/src/main/java/com/wanikani/api/v2/request/QueryStringUtils.java
+++ b/src/main/java/com/wanikani/api/v2/request/QueryStringUtils.java
@@ -2,10 +2,12 @@ package com.wanikani.api.v2.request;
 
 import com.wanikani.api.v2.util.DateUtils;
 
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 class QueryStringUtils {
+
 
     public static <T> void append(StringBuilder queryString, String parameter, T value) {
         if (value == null) {
@@ -26,7 +28,7 @@ class QueryStringUtils {
         queryString.deleteCharAt(queryString.length() - 1);
     }
 
-    public static void appendDate(StringBuilder queryString, String parameter, Date date) {
+    public static void appendDate(StringBuilder queryString, String parameter, LocalDateTime date) {
         if (date == null) {
             return;
         }

--- a/src/main/java/com/wanikani/api/v2/request/QueryStringUtils.java
+++ b/src/main/java/com/wanikani/api/v2/request/QueryStringUtils.java
@@ -2,7 +2,7 @@ package com.wanikani.api.v2.request;
 
 import com.wanikani.api.v2.util.DateUtils;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -28,7 +28,7 @@ class QueryStringUtils {
         queryString.deleteCharAt(queryString.length() - 1);
     }
 
-    public static void appendDate(StringBuilder queryString, String parameter, LocalDateTime date) {
+    public static void appendDate(StringBuilder queryString, String parameter, ZonedDateTime date) {
         if (date == null) {
             return;
         }

--- a/src/main/java/com/wanikani/api/v2/request/QueryStringUtils.java
+++ b/src/main/java/com/wanikani/api/v2/request/QueryStringUtils.java
@@ -3,11 +3,9 @@ package com.wanikani.api.v2.request;
 import com.wanikani.api.v2.util.DateUtils;
 
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 class QueryStringUtils {
-
 
     public static <T> void append(StringBuilder queryString, String parameter, T value) {
         if (value == null) {

--- a/src/main/java/com/wanikani/api/v2/request/ReviewStatisticsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/ReviewStatisticsRequest.java
@@ -2,6 +2,8 @@ package com.wanikani.api.v2.request;
 
 import com.wanikani.api.v2.model.SubjectType;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.time.ZonedDateTime;
@@ -28,14 +30,13 @@ public class ReviewStatisticsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder {
+    public static class Builder extends BaseBuilder<ReviewStatisticsRequest, Builder> {
         private List<Long> ids = new ArrayList<>();
         private List<Long> subjectIds = new ArrayList<>();
         private List<String> subjectTypes = new ArrayList<>();
         private Integer percentagesGreaterThan;
         private Integer percentagesLessThan;
         private Boolean hidden;
-        private ZonedDateTime updatedAfter;
         private Long pageAfterId = null;
 
         public Builder pageAfterId(Long pageAfterId) {
@@ -77,14 +78,9 @@ public class ReviewStatisticsRequest implements Request {
             return this;
         }
 
-        public Builder updatedAfter(ZonedDateTime updatedAfter) {
-            this.updatedAfter = updatedAfter;
-            return this;
-        }
-
+        @Override
         public ReviewStatisticsRequest build() {
-            StringBuilder queryString = new StringBuilder();
-            appendDate(queryString, "updated_after", updatedAfter);
+            StringBuilder queryString = super.queryString();
             appendList(queryString, "ids", ids);
             appendList(queryString, "subject_ids", subjectIds);
             appendList(queryString, "subject_types", subjectTypes);

--- a/src/main/java/com/wanikani/api/v2/request/ReviewStatisticsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/ReviewStatisticsRequest.java
@@ -4,7 +4,7 @@ import com.wanikani.api.v2.model.SubjectType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.wanikani.api.v2.request.QueryStringUtils.append;
@@ -35,7 +35,7 @@ public class ReviewStatisticsRequest implements Request {
         private Integer percentagesGreaterThan;
         private Integer percentagesLessThan;
         private Boolean hidden;
-        private Date updatedAfter;
+        private LocalDateTime updatedAfter;
         private Long pageAfterId = null;
 
         public Builder pageAfterId(Long pageAfterId) {
@@ -77,7 +77,7 @@ public class ReviewStatisticsRequest implements Request {
             return this;
         }
 
-        public Builder updatedAfter(Date updatedAfter) {
+        public Builder updatedAfter(LocalDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/ReviewStatisticsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/ReviewStatisticsRequest.java
@@ -2,15 +2,11 @@ package com.wanikani.api.v2.request;
 
 import com.wanikani.api.v2.model.SubjectType;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.time.ZonedDateTime;
 import java.util.List;
 
 import static com.wanikani.api.v2.request.QueryStringUtils.append;
-import static com.wanikani.api.v2.request.QueryStringUtils.appendDate;
 import static com.wanikani.api.v2.request.QueryStringUtils.appendList;
 import static java.util.stream.Collectors.toList;
 
@@ -30,24 +26,12 @@ public class ReviewStatisticsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder extends BaseBuilder<ReviewStatisticsRequest, Builder> {
-        private List<Long> ids = new ArrayList<>();
+    public static class Builder extends CollectionBuilder<ReviewStatisticsRequest, Builder> {
         private List<Long> subjectIds = new ArrayList<>();
         private List<String> subjectTypes = new ArrayList<>();
         private Integer percentagesGreaterThan;
         private Integer percentagesLessThan;
         private Boolean hidden;
-        private Long pageAfterId = null;
-
-        public Builder pageAfterId(Long pageAfterId) {
-            this.pageAfterId = pageAfterId;
-            return this;
-        }
-
-        public Builder ids(List<Long> ids) {
-            this.ids = ids;
-            return this;
-        }
 
         public Builder subjectIds(List<Long> subjectIds) {
             this.subjectIds = subjectIds;
@@ -81,10 +65,8 @@ public class ReviewStatisticsRequest implements Request {
         @Override
         public ReviewStatisticsRequest build() {
             StringBuilder queryString = super.queryString();
-            appendList(queryString, "ids", ids);
             appendList(queryString, "subject_ids", subjectIds);
             appendList(queryString, "subject_types", subjectTypes);
-            append(queryString, "page_after_id", pageAfterId);
             append(queryString, "percentages_greater_than", percentagesGreaterThan);
             append(queryString, "percentages_less_than", percentagesLessThan);
             append(queryString, "hidden", hidden);

--- a/src/main/java/com/wanikani/api/v2/request/ReviewStatisticsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/ReviewStatisticsRequest.java
@@ -4,7 +4,7 @@ import com.wanikani.api.v2.model.SubjectType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import static com.wanikani.api.v2.request.QueryStringUtils.append;
@@ -35,7 +35,7 @@ public class ReviewStatisticsRequest implements Request {
         private Integer percentagesGreaterThan;
         private Integer percentagesLessThan;
         private Boolean hidden;
-        private LocalDateTime updatedAfter;
+        private ZonedDateTime updatedAfter;
         private Long pageAfterId = null;
 
         public Builder pageAfterId(Long pageAfterId) {
@@ -77,7 +77,7 @@ public class ReviewStatisticsRequest implements Request {
             return this;
         }
 
-        public Builder updatedAfter(LocalDateTime updatedAfter) {
+        public Builder updatedAfter(ZonedDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/ReviewsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/ReviewsRequest.java
@@ -1,14 +1,9 @@
 package com.wanikani.api.v2.request;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.time.ZonedDateTime;
 import java.util.List;
 
-import static com.wanikani.api.v2.request.QueryStringUtils.append;
-import static com.wanikani.api.v2.request.QueryStringUtils.appendDate;
 import static com.wanikani.api.v2.request.QueryStringUtils.appendList;
 
 public class ReviewsRequest implements Request {
@@ -27,16 +22,9 @@ public class ReviewsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder extends BaseBuilder<ReviewsRequest, Builder> {
-        private List<Long> ids = new ArrayList<>();
+    public static class Builder extends CollectionBuilder<ReviewsRequest, Builder> {
         private List<Long> assignmentIds = new ArrayList<>();
         private List<Long> subjectIds = new ArrayList<>();
-        private Long pageAfterId;
-
-        public Builder ids(Long... ids) {
-            this.ids = Arrays.asList(ids);
-            return this;
-        }
 
         public Builder assignmentIds(Long... ids) {
             this.assignmentIds = Arrays.asList(ids);
@@ -52,18 +40,11 @@ public class ReviewsRequest implements Request {
             return subjectIds(Arrays.asList(ids));
         }
 
-        public Builder pageAfterId(Long id) {
-            this.pageAfterId = id;
-            return this;
-        }
-
         @Override
         public ReviewsRequest build() {
             StringBuilder queryString = super.queryString();
-            appendList(queryString, "ids", ids);
             appendList(queryString, "assignment_ids", assignmentIds);
             appendList(queryString, "subject_ids", subjectIds);
-            append(queryString, "page_after_id", pageAfterId);
             return new ReviewsRequest(queryString.toString());
         }
     }

--- a/src/main/java/com/wanikani/api/v2/request/ReviewsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/ReviewsRequest.java
@@ -2,7 +2,7 @@ package com.wanikani.api.v2.request;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.wanikani.api.v2.request.QueryStringUtils.append;
@@ -30,7 +30,7 @@ public class ReviewsRequest implements Request {
         private List<Long> assignmentIds = new ArrayList<>();
         private List<Long> subjectIds = new ArrayList<>();
         private Long pageAfterId;
-        private Date updatedAfter;
+        private LocalDateTime updatedAfter;
 
         public Builder ids(Long... ids) {
             this.ids = Arrays.asList(ids);
@@ -51,7 +51,7 @@ public class ReviewsRequest implements Request {
             return subjectIds(Arrays.asList(ids));
         }
 
-        public Builder updatedAfter(Date updatedAfter) {
+        public Builder updatedAfter(LocalDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/ReviewsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/ReviewsRequest.java
@@ -27,12 +27,11 @@ public class ReviewsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder {
+    public static class Builder extends BaseBuilder<ReviewsRequest, Builder> {
         private List<Long> ids = new ArrayList<>();
         private List<Long> assignmentIds = new ArrayList<>();
         private List<Long> subjectIds = new ArrayList<>();
         private Long pageAfterId;
-        private ZonedDateTime updatedAfter;
 
         public Builder ids(Long... ids) {
             this.ids = Arrays.asList(ids);
@@ -53,22 +52,17 @@ public class ReviewsRequest implements Request {
             return subjectIds(Arrays.asList(ids));
         }
 
-        public Builder updatedAfter(ZonedDateTime updatedAfter) {
-            this.updatedAfter = updatedAfter;
-            return this;
-        }
-
         public Builder pageAfterId(Long id) {
             this.pageAfterId = id;
             return this;
         }
 
+        @Override
         public ReviewsRequest build() {
-            StringBuilder queryString = new StringBuilder();
+            StringBuilder queryString = super.queryString();
             appendList(queryString, "ids", ids);
             appendList(queryString, "assignment_ids", assignmentIds);
             appendList(queryString, "subject_ids", subjectIds);
-            appendDate(queryString, "updated_after", updatedAfter);
             append(queryString, "page_after_id", pageAfterId);
             return new ReviewsRequest(queryString.toString());
         }

--- a/src/main/java/com/wanikani/api/v2/request/ReviewsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/ReviewsRequest.java
@@ -1,8 +1,10 @@
 package com.wanikani.api.v2.request;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import static com.wanikani.api.v2.request.QueryStringUtils.append;
@@ -30,7 +32,7 @@ public class ReviewsRequest implements Request {
         private List<Long> assignmentIds = new ArrayList<>();
         private List<Long> subjectIds = new ArrayList<>();
         private Long pageAfterId;
-        private LocalDateTime updatedAfter;
+        private ZonedDateTime updatedAfter;
 
         public Builder ids(Long... ids) {
             this.ids = Arrays.asList(ids);
@@ -51,7 +53,7 @@ public class ReviewsRequest implements Request {
             return subjectIds(Arrays.asList(ids));
         }
 
-        public Builder updatedAfter(LocalDateTime updatedAfter) {
+        public Builder updatedAfter(ZonedDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/SpacedRepetitionSystemsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/SpacedRepetitionSystemsRequest.java
@@ -2,7 +2,7 @@ package com.wanikani.api.v2.request;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,7 +27,7 @@ public class SpacedRepetitionSystemsRequest implements Request {
 
     public static class Builder {
         private List<Long> ids = new ArrayList<>();
-        private LocalDateTime updatedAfter;
+        private ZonedDateTime updatedAfter;
 
         public Builder ids(List<Long> ids) {
             this.ids = ids;
@@ -38,7 +38,7 @@ public class SpacedRepetitionSystemsRequest implements Request {
             return ids(Arrays.stream(ids).boxed().collect(Collectors.toList()));
         }
 
-        public Builder updatedAfter(LocalDateTime updatedAfter) {
+        public Builder updatedAfter(ZonedDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/SpacedRepetitionSystemsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/SpacedRepetitionSystemsRequest.java
@@ -2,7 +2,7 @@ package com.wanikani.api.v2.request;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,7 +27,7 @@ public class SpacedRepetitionSystemsRequest implements Request {
 
     public static class Builder {
         private List<Long> ids = new ArrayList<>();
-        private Date updatedAfter;
+        private LocalDateTime updatedAfter;
 
         public Builder ids(List<Long> ids) {
             this.ids = ids;
@@ -38,7 +38,7 @@ public class SpacedRepetitionSystemsRequest implements Request {
             return ids(Arrays.stream(ids).boxed().collect(Collectors.toList()));
         }
 
-        public Builder updatedAfter(Date updatedAfter) {
+        public Builder updatedAfter(LocalDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/SpacedRepetitionSystemsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/SpacedRepetitionSystemsRequest.java
@@ -1,16 +1,5 @@
 package com.wanikani.api.v2.request;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static com.wanikani.api.v2.request.QueryStringUtils.appendDate;
-import static com.wanikani.api.v2.request.QueryStringUtils.appendList;
-
 public class SpacedRepetitionSystemsRequest implements Request {
 
     private final String queryString;
@@ -27,22 +16,11 @@ public class SpacedRepetitionSystemsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder extends BaseBuilder<SpacedRepetitionSystemsRequest, Builder> {
-        private List<Long> ids = new ArrayList<>();
-
-        public Builder ids(List<Long> ids) {
-            this.ids = ids;
-            return this;
-        }
-
-        public Builder ids(long... ids) {
-            return ids(Arrays.stream(ids).boxed().collect(Collectors.toList()));
-        }
+    public static class Builder extends CollectionBuilder<SpacedRepetitionSystemsRequest, Builder> {
 
         @Override
         public SpacedRepetitionSystemsRequest build() {
             StringBuilder queryString = super.queryString();
-            appendList(queryString, "ids", ids);
             return new SpacedRepetitionSystemsRequest(queryString.toString());
         }
     }

--- a/src/main/java/com/wanikani/api/v2/request/SpacedRepetitionSystemsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/SpacedRepetitionSystemsRequest.java
@@ -1,5 +1,7 @@
 package com.wanikani.api.v2.request;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.time.ZonedDateTime;
@@ -25,9 +27,8 @@ public class SpacedRepetitionSystemsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder {
+    public static class Builder extends BaseBuilder<SpacedRepetitionSystemsRequest, Builder> {
         private List<Long> ids = new ArrayList<>();
-        private ZonedDateTime updatedAfter;
 
         public Builder ids(List<Long> ids) {
             this.ids = ids;
@@ -38,14 +39,9 @@ public class SpacedRepetitionSystemsRequest implements Request {
             return ids(Arrays.stream(ids).boxed().collect(Collectors.toList()));
         }
 
-        public Builder updatedAfter(ZonedDateTime updatedAfter) {
-            this.updatedAfter = updatedAfter;
-            return this;
-        }
-
+        @Override
         public SpacedRepetitionSystemsRequest build() {
-            StringBuilder queryString = new StringBuilder();
-            appendDate(queryString, "updated_after", updatedAfter);
+            StringBuilder queryString = super.queryString();
             appendList(queryString, "ids", ids);
             return new SpacedRepetitionSystemsRequest(queryString.toString());
         }

--- a/src/main/java/com/wanikani/api/v2/request/StudyMaterialsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/StudyMaterialsRequest.java
@@ -5,7 +5,7 @@ import com.wanikani.api.v2.model.SubjectType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -36,7 +36,7 @@ public class StudyMaterialsRequest implements Request {
         private List<Long> ids = new ArrayList<>();
         private List<Long> subjectIds = new ArrayList<>();
         private List<String> subjectTypes = new ArrayList<>();
-        private Date updatedAfter;
+        private LocalDateTime updatedAfter;
 
         public Builder hidden(boolean hidden) {
             this.hidden = hidden;
@@ -70,7 +70,7 @@ public class StudyMaterialsRequest implements Request {
             return subjectTypes(Arrays.stream(subjectTypes).collect(Collectors.toList()));
         }
 
-        public Builder updatedAfter(Date updatedAfter) {
+        public Builder updatedAfter(LocalDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/StudyMaterialsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/StudyMaterialsRequest.java
@@ -2,6 +2,8 @@ package com.wanikani.api.v2.request;
 
 import com.wanikani.api.v2.model.SubjectType;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -31,12 +33,11 @@ public class StudyMaterialsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder {
+    public static class Builder extends BaseBuilder<StudyMaterialsRequest, Builder> {
         private Boolean hidden;
         private List<Long> ids = new ArrayList<>();
         private List<Long> subjectIds = new ArrayList<>();
         private List<String> subjectTypes = new ArrayList<>();
-        private ZonedDateTime updatedAfter;
 
         public Builder hidden(boolean hidden) {
             this.hidden = hidden;
@@ -70,18 +71,13 @@ public class StudyMaterialsRequest implements Request {
             return subjectTypes(Arrays.stream(subjectTypes).collect(Collectors.toList()));
         }
 
-        public Builder updatedAfter(ZonedDateTime updatedAfter) {
-            this.updatedAfter = updatedAfter;
-            return this;
-        }
-
+        @Override
         public StudyMaterialsRequest build() {
-            StringBuilder queryString = new StringBuilder();
+            StringBuilder queryString = super.queryString();
             append(queryString, "hidden", hidden);
             appendList(queryString, "ids", ids);
             appendList(queryString, "subject_ids", subjectIds);
             appendList(queryString, "subject_types", subjectTypes);
-            appendDate(queryString, "updated_after", updatedAfter);
 
             return new StudyMaterialsRequest(queryString.toString());
         }

--- a/src/main/java/com/wanikani/api/v2/request/StudyMaterialsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/StudyMaterialsRequest.java
@@ -2,19 +2,12 @@ package com.wanikani.api.v2.request;
 
 import com.wanikani.api.v2.model.SubjectType;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.time.ZonedDateTime;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.wanikani.api.v2.request.QueryStringUtils.append;
-import static com.wanikani.api.v2.request.QueryStringUtils.appendDate;
 import static com.wanikani.api.v2.request.QueryStringUtils.appendList;
 
 public class StudyMaterialsRequest implements Request {

--- a/src/main/java/com/wanikani/api/v2/request/StudyMaterialsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/StudyMaterialsRequest.java
@@ -33,24 +33,14 @@ public class StudyMaterialsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder extends BaseBuilder<StudyMaterialsRequest, Builder> {
+    public static class Builder extends CollectionBuilder<StudyMaterialsRequest, Builder> {
         private Boolean hidden;
-        private List<Long> ids = new ArrayList<>();
         private List<Long> subjectIds = new ArrayList<>();
         private List<String> subjectTypes = new ArrayList<>();
 
         public Builder hidden(boolean hidden) {
             this.hidden = hidden;
             return this;
-        }
-
-        public Builder ids(List<Long> ids) {
-            this.ids = ids;
-            return this;
-        }
-
-        public Builder ids(long... ids) {
-            return ids(Arrays.stream(ids).boxed().collect(Collectors.toList()));
         }
 
         public Builder subjectIds(List<Long> subjectIds) {
@@ -75,10 +65,8 @@ public class StudyMaterialsRequest implements Request {
         public StudyMaterialsRequest build() {
             StringBuilder queryString = super.queryString();
             append(queryString, "hidden", hidden);
-            appendList(queryString, "ids", ids);
             appendList(queryString, "subject_ids", subjectIds);
             appendList(queryString, "subject_types", subjectTypes);
-
             return new StudyMaterialsRequest(queryString.toString());
         }
     }

--- a/src/main/java/com/wanikani/api/v2/request/StudyMaterialsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/StudyMaterialsRequest.java
@@ -5,7 +5,7 @@ import com.wanikani.api.v2.model.SubjectType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -36,7 +36,7 @@ public class StudyMaterialsRequest implements Request {
         private List<Long> ids = new ArrayList<>();
         private List<Long> subjectIds = new ArrayList<>();
         private List<String> subjectTypes = new ArrayList<>();
-        private LocalDateTime updatedAfter;
+        private ZonedDateTime updatedAfter;
 
         public Builder hidden(boolean hidden) {
             this.hidden = hidden;
@@ -70,7 +70,7 @@ public class StudyMaterialsRequest implements Request {
             return subjectTypes(Arrays.stream(subjectTypes).collect(Collectors.toList()));
         }
 
-        public Builder updatedAfter(LocalDateTime updatedAfter) {
+        public Builder updatedAfter(ZonedDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/SubjectsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/SubjectsRequest.java
@@ -30,12 +30,11 @@ public class SubjectsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder extends BaseBuilder<SubjectsRequest, Builder> {
+    public static class Builder extends CollectionBuilder<SubjectsRequest, Builder> {
         private final List<Integer> levels = new ArrayList<>();
         private List<String> types = new ArrayList<>();
         private List<String> slugs = new ArrayList<>();
         private Boolean hidden;
-        private Long pageAfterId;
 
         public Builder slugs(List<String> slugs) {
             this.slugs = slugs;
@@ -44,11 +43,6 @@ public class SubjectsRequest implements Request {
 
         public Builder hidden(Boolean hidden) {
             this.hidden = hidden;
-            return this;
-        }
-
-        public Builder pageAfterId(Long pageAfterId) {
-            this.pageAfterId = pageAfterId;
             return this;
         }
 
@@ -78,7 +72,6 @@ public class SubjectsRequest implements Request {
             StringBuilder queryString = super.queryString();
             appendList(queryString, "types", types);
             appendList(queryString, "levels", levels);
-            append(queryString, "page_after_id", pageAfterId);
             appendList(queryString, "slugs", slugs);
             append(queryString, "hidden", hidden);
             return new SubjectsRequest(queryString.toString());

--- a/src/main/java/com/wanikani/api/v2/request/SubjectsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/SubjectsRequest.java
@@ -3,7 +3,7 @@ package com.wanikani.api.v2.request;
 import com.wanikani.api.v2.model.SubjectType;
 
 import java.util.ArrayList;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -33,7 +33,7 @@ public class SubjectsRequest implements Request {
         private final List<Integer> levels = new ArrayList<>();
         private List<String> slugs = new ArrayList<>();
         private Boolean hidden;
-        private Date updatedAfter;
+        private LocalDateTime updatedAfter;
         private Long pageAfterId;
 
         public Builder slugs(List<String> slugs) {
@@ -46,7 +46,7 @@ public class SubjectsRequest implements Request {
             return this;
         }
 
-        public Builder updatedAfter(Date updatedAfter) {
+        public Builder updatedAfter(LocalDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/SubjectsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/SubjectsRequest.java
@@ -2,15 +2,11 @@ package com.wanikani.api.v2.request;
 
 import com.wanikani.api.v2.model.SubjectType;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
 import static com.wanikani.api.v2.request.QueryStringUtils.append;
-import static com.wanikani.api.v2.request.QueryStringUtils.appendDate;
 import static com.wanikani.api.v2.request.QueryStringUtils.appendList;
 import static java.util.stream.Collectors.toList;
 

--- a/src/main/java/com/wanikani/api/v2/request/SubjectsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/SubjectsRequest.java
@@ -3,7 +3,7 @@ package com.wanikani.api.v2.request;
 import com.wanikani.api.v2.model.SubjectType;
 
 import java.util.ArrayList;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -33,7 +33,7 @@ public class SubjectsRequest implements Request {
         private final List<Integer> levels = new ArrayList<>();
         private List<String> slugs = new ArrayList<>();
         private Boolean hidden;
-        private LocalDateTime updatedAfter;
+        private ZonedDateTime updatedAfter;
         private Long pageAfterId;
 
         public Builder slugs(List<String> slugs) {
@@ -46,7 +46,7 @@ public class SubjectsRequest implements Request {
             return this;
         }
 
-        public Builder updatedAfter(LocalDateTime updatedAfter) {
+        public Builder updatedAfter(ZonedDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/SubjectsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/SubjectsRequest.java
@@ -2,8 +2,10 @@ package com.wanikani.api.v2.request;
 
 import com.wanikani.api.v2.model.SubjectType;
 
-import java.util.ArrayList;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -28,12 +30,11 @@ public class SubjectsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder {
-        private List<String> types = new ArrayList<>();
+    public static class Builder extends BaseBuilder<SubjectsRequest, Builder> {
         private final List<Integer> levels = new ArrayList<>();
+        private List<String> types = new ArrayList<>();
         private List<String> slugs = new ArrayList<>();
         private Boolean hidden;
-        private ZonedDateTime updatedAfter;
         private Long pageAfterId;
 
         public Builder slugs(List<String> slugs) {
@@ -43,11 +44,6 @@ public class SubjectsRequest implements Request {
 
         public Builder hidden(Boolean hidden) {
             this.hidden = hidden;
-            return this;
-        }
-
-        public Builder updatedAfter(ZonedDateTime updatedAfter) {
-            this.updatedAfter = updatedAfter;
             return this;
         }
 
@@ -77,14 +73,14 @@ public class SubjectsRequest implements Request {
             return this.levels(stream.toArray());
         }
 
+        @Override
         public SubjectsRequest build() {
-            StringBuilder queryString = new StringBuilder();
+            StringBuilder queryString = super.queryString();
             appendList(queryString, "types", types);
             appendList(queryString, "levels", levels);
             append(queryString, "page_after_id", pageAfterId);
             appendList(queryString, "slugs", slugs);
             append(queryString, "hidden", hidden);
-            appendDate(queryString, "updated_after", updatedAfter);
             return new SubjectsRequest(queryString.toString());
         }
     }

--- a/src/main/java/com/wanikani/api/v2/request/VoiceActorsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/VoiceActorsRequest.java
@@ -2,7 +2,7 @@ package com.wanikani.api.v2.request;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,7 +27,7 @@ public class VoiceActorsRequest implements Request {
 
     public static class Builder {
         private List<Long> ids = new ArrayList<>();
-        private Date updatedAfter;
+        private LocalDateTime updatedAfter;
 
         public Builder ids(List<Long> ids) {
             this.ids = ids;
@@ -38,7 +38,7 @@ public class VoiceActorsRequest implements Request {
             return ids(Arrays.stream(ids).boxed().collect(Collectors.toList()));
         }
 
-        public Builder updatedAfter(Date updatedAfter) {
+        public Builder updatedAfter(LocalDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/VoiceActorsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/VoiceActorsRequest.java
@@ -1,16 +1,5 @@
 package com.wanikani.api.v2.request;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static com.wanikani.api.v2.request.QueryStringUtils.appendDate;
-import static com.wanikani.api.v2.request.QueryStringUtils.appendList;
-
 public class VoiceActorsRequest implements Request {
 
     private final String queryString;
@@ -27,22 +16,11 @@ public class VoiceActorsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder extends BaseBuilder<VoiceActorsRequest, Builder> {
-        private List<Long> ids = new ArrayList<>();
-
-        public Builder ids(List<Long> ids) {
-            this.ids = ids;
-            return this;
-        }
-
-        public Builder ids(long... ids) {
-            return ids(Arrays.stream(ids).boxed().collect(Collectors.toList()));
-        }
+    public static class Builder extends CollectionBuilder<VoiceActorsRequest, Builder> {
 
         @Override
         public VoiceActorsRequest build() {
             StringBuilder queryString = super.queryString();
-            appendList(queryString, "ids", ids);
             return new VoiceActorsRequest(queryString.toString());
         }
     }

--- a/src/main/java/com/wanikani/api/v2/request/VoiceActorsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/VoiceActorsRequest.java
@@ -2,7 +2,7 @@ package com.wanikani.api.v2.request;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,7 +27,7 @@ public class VoiceActorsRequest implements Request {
 
     public static class Builder {
         private List<Long> ids = new ArrayList<>();
-        private LocalDateTime updatedAfter;
+        private ZonedDateTime updatedAfter;
 
         public Builder ids(List<Long> ids) {
             this.ids = ids;
@@ -38,7 +38,7 @@ public class VoiceActorsRequest implements Request {
             return ids(Arrays.stream(ids).boxed().collect(Collectors.toList()));
         }
 
-        public Builder updatedAfter(LocalDateTime updatedAfter) {
+        public Builder updatedAfter(ZonedDateTime updatedAfter) {
             this.updatedAfter = updatedAfter;
             return this;
         }

--- a/src/main/java/com/wanikani/api/v2/request/VoiceActorsRequest.java
+++ b/src/main/java/com/wanikani/api/v2/request/VoiceActorsRequest.java
@@ -1,8 +1,10 @@
 package com.wanikani.api.v2.request;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,9 +27,8 @@ public class VoiceActorsRequest implements Request {
         return queryString;
     }
 
-    public static class Builder {
+    public static class Builder extends BaseBuilder<VoiceActorsRequest, Builder> {
         private List<Long> ids = new ArrayList<>();
-        private ZonedDateTime updatedAfter;
 
         public Builder ids(List<Long> ids) {
             this.ids = ids;
@@ -38,14 +39,9 @@ public class VoiceActorsRequest implements Request {
             return ids(Arrays.stream(ids).boxed().collect(Collectors.toList()));
         }
 
-        public Builder updatedAfter(ZonedDateTime updatedAfter) {
-            this.updatedAfter = updatedAfter;
-            return this;
-        }
-
+        @Override
         public VoiceActorsRequest build() {
-            StringBuilder queryString = new StringBuilder();
-            appendDate(queryString, "updated_after", updatedAfter);
+            StringBuilder queryString = super.queryString();
             appendList(queryString, "ids", ids);
             return new VoiceActorsRequest(queryString.toString());
         }

--- a/src/main/java/com/wanikani/api/v2/util/DateUtils.java
+++ b/src/main/java/com/wanikani/api/v2/util/DateUtils.java
@@ -1,12 +1,13 @@
 package com.wanikani.api.v2.util;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class DateUtils {
 
     public static String getApiDate(ZonedDateTime date) {
-        return DateTimeFormatter.ISO_DATE_TIME.format(date);
+        return DateTimeFormatter.ISO_DATE_TIME.format(date.withZoneSameInstant(ZoneOffset.UTC));
     }
 
     public static ZonedDateTime getApiDate(String date) {

--- a/src/main/java/com/wanikani/api/v2/util/DateUtils.java
+++ b/src/main/java/com/wanikani/api/v2/util/DateUtils.java
@@ -1,30 +1,16 @@
 package com.wanikani.api.v2.util;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 public class DateUtils {
 
-    private static final String FROM_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
-    private static final String TO_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-
-    public static Date getApiDate(String apiDate) {
-        SimpleDateFormat format = new SimpleDateFormat(FROM_FORMAT);
-        TimeZone timeZone = TimeZone.getTimeZone("UTC");
-        format.setTimeZone(timeZone);
-        try {
-            return format.parse(apiDate);
-        } catch (ParseException e) {
-            return null;
-        }
+    public static String getApiDate(LocalDateTime date) {
+        return DateTimeFormatter.ISO_DATE_TIME.format(date.atZone(ZoneOffset.UTC));
     }
 
-    public static String getApiDate(Date date) {
-        SimpleDateFormat format = new SimpleDateFormat(TO_FORMAT);
-        TimeZone timeZone = TimeZone.getTimeZone("UTC");
-        format.setTimeZone(timeZone);
-        return format.format(date);
+    public static LocalDateTime getApiDate(String date) {
+        return LocalDateTime.parse(date, DateTimeFormatter.ISO_DATE_TIME);
     }
 }

--- a/src/main/java/com/wanikani/api/v2/util/DateUtils.java
+++ b/src/main/java/com/wanikani/api/v2/util/DateUtils.java
@@ -1,16 +1,15 @@
 package com.wanikani.api.v2.util;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class DateUtils {
 
-    public static String getApiDate(LocalDateTime date) {
-        return DateTimeFormatter.ISO_DATE_TIME.format(date.atZone(ZoneOffset.UTC));
+    public static String getApiDate(ZonedDateTime date) {
+        return DateTimeFormatter.ISO_DATE_TIME.format(date);
     }
 
-    public static LocalDateTime getApiDate(String date) {
-        return LocalDateTime.parse(date, DateTimeFormatter.ISO_DATE_TIME);
+    public static ZonedDateTime getApiDate(String date) {
+        return ZonedDateTime.parse(date, DateTimeFormatter.ISO_DATE_TIME);
     }
 }

--- a/src/test/java/com/wanikani/api/v2/request/AssignmentsRequestTest.java
+++ b/src/test/java/com/wanikani/api/v2/request/AssignmentsRequestTest.java
@@ -24,6 +24,6 @@ public class AssignmentsRequestTest {
             .started(true)
             .updatedAfter(updatedAfter)
             .build();
-        assertEquals("?subject_types=kanji,radical&updated_after=2018-11-25T19:22:12.856Z&srs_stages=1,4,5&started=true&burned=false", request.getQueryString());
+        assertEquals("?updated_after=2018-11-25T19:22:12.856Z&subject_types=kanji,radical&srs_stages=1,4,5&started=true&burned=false", request.getQueryString());
     }
 }

--- a/src/test/java/com/wanikani/api/v2/request/AssignmentsRequestTest.java
+++ b/src/test/java/com/wanikani/api/v2/request/AssignmentsRequestTest.java
@@ -3,8 +3,8 @@ package com.wanikani.api.v2.request;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import static com.wanikani.api.v2.model.SubjectType.KANJI;
 import static com.wanikani.api.v2.model.SubjectType.RADICAL;
@@ -15,7 +15,7 @@ public class AssignmentsRequestTest {
     @Test
     public void testQueryStringGeneration() {
         // Sunday, November 25, 2018 7:22:12 PM UTC
-        LocalDateTime updatedAfter = LocalDateTime.ofEpochSecond(1543173732L, 856000000, ZoneOffset.UTC);
+        ZonedDateTime updatedAfter = Instant.ofEpochMilli(1543173732856L).atZone(ZoneOffset.UTC);
         AssignmentsRequest request = AssignmentsRequest
             .builder()
             .subjectTypes(KANJI, RADICAL)

--- a/src/test/java/com/wanikani/api/v2/request/AssignmentsRequestTest.java
+++ b/src/test/java/com/wanikani/api/v2/request/AssignmentsRequestTest.java
@@ -2,7 +2,9 @@ package com.wanikani.api.v2.request;
 
 import org.junit.Test;
 
-import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 import static com.wanikani.api.v2.model.SubjectType.KANJI;
 import static com.wanikani.api.v2.model.SubjectType.RADICAL;
@@ -12,15 +14,16 @@ public class AssignmentsRequestTest {
 
     @Test
     public void testQueryStringGeneration() {
+        // Sunday, November 25, 2018 7:22:12 PM UTC
+        LocalDateTime updatedAfter = LocalDateTime.ofEpochSecond(1543173732L, 856000000, ZoneOffset.UTC);
         AssignmentsRequest request = AssignmentsRequest
             .builder()
             .subjectTypes(KANJI, RADICAL)
             .srsStages(1, 4, 5)
             .burned(false)
             .started(true)
-            .updatedAfter(new Date(1543173732856L))
+            .updatedAfter(updatedAfter)
             .build();
-
         assertEquals("?subject_types=kanji,radical&updated_after=2018-11-25T19:22:12.856Z&srs_stages=1,4,5&started=true&burned=false", request.getQueryString());
     }
 }

--- a/src/test/java/com/wanikani/api/v2/request/StudyMaterialsRequestTest.java
+++ b/src/test/java/com/wanikani/api/v2/request/StudyMaterialsRequestTest.java
@@ -1,0 +1,29 @@
+package com.wanikani.api.v2.request;
+
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.Assert.assertEquals;
+
+public class StudyMaterialsRequestTest {
+
+    @Test
+    public void testQueryString() {
+        String utcTime = "2022-12-02T19:35:35Z";
+        final Instant instant = Instant.ofEpochMilli(1670009735000L);
+        final StudyMaterialsRequest requestOffset5 = StudyMaterialsRequest.builder()
+            .updatedAfter(instant.atZone(ZoneOffset.ofHours(5)))
+            .build();
+        final StudyMaterialsRequest requestNoOffset = StudyMaterialsRequest.builder()
+            .updatedAfter(instant.atZone(ZoneOffset.UTC))
+            .build();
+        final StudyMaterialsRequest requestOffsetMinus10 = StudyMaterialsRequest.builder()
+            .updatedAfter(instant.atZone(ZoneOffset.ofHours(-10)))
+            .build();
+        assertEquals("?updated_after=" + utcTime, requestOffset5.getQueryString());
+        assertEquals("?updated_after=" + utcTime, requestNoOffset.getQueryString());
+        assertEquals("?updated_after=" + utcTime, requestOffsetMinus10.getQueryString());
+    }
+}

--- a/src/test/java/com/wanikani/api/v2/util/DateUtilsTest.java
+++ b/src/test/java/com/wanikani/api/v2/util/DateUtilsTest.java
@@ -2,26 +2,32 @@ package com.wanikani.api.v2.util;
 
 import org.junit.Test;
 
-import java.time.ZoneId;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoField;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class DateUtilsTest {
 
     @Test
-    public void testGetApiDate() {
-        Date date = DateUtils.getApiDate("2018-11-22T12:52:38.861676Z");
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTimeZone(TimeZone.getTimeZone(ZoneId.of("UTC")));
-        calendar.setTime(date);
-        assertEquals(10, calendar.get(Calendar.MONTH));
-        assertEquals(22, calendar.get(Calendar.DAY_OF_MONTH));
-        assertEquals(12, calendar.get(Calendar.HOUR_OF_DAY));
-        assertEquals(52, calendar.get(Calendar.MINUTE));
-        assertEquals(38, calendar.get(Calendar.SECOND));
-        assertEquals(0, calendar.get(Calendar.MILLISECOND));
+    public void testDeserialization() {
+        final LocalDateTime date = DateUtils.getApiDate("2022-10-07T00:42:53.811877Z");
+        assertEquals(2022, date.get(ChronoField.YEAR));
+        assertEquals(10, date.get(ChronoField.MONTH_OF_YEAR));
+        assertEquals(7, date.get(ChronoField.DAY_OF_MONTH));
+        assertEquals(0, date.get(ChronoField.HOUR_OF_DAY));
+        assertEquals(42, date.get(ChronoField.MINUTE_OF_HOUR));
+        assertEquals(53, date.get(ChronoField.SECOND_OF_MINUTE));
+        assertEquals(811, date.get(ChronoField.MILLI_OF_SECOND));
+    }
+
+    @Test
+    public void testSerialization() {
+        LocalDateTime time = Instant.ofEpochMilli(1667431825313L).atZone(ZoneOffset.UTC).toLocalDateTime();
+        String result = DateUtils.getApiDate(time);
+        System.out.println(result);
+        assertEquals("2022-11-02T23:30:25.313Z", result);
     }
 }

--- a/src/test/java/com/wanikani/api/v2/util/DateUtilsTest.java
+++ b/src/test/java/com/wanikani/api/v2/util/DateUtilsTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 
 import static org.junit.Assert.assertEquals;
@@ -13,7 +14,7 @@ public class DateUtilsTest {
 
     @Test
     public void testDeserialization() {
-        final LocalDateTime date = DateUtils.getApiDate("2022-10-07T00:42:53.811877Z");
+        final ZonedDateTime date = DateUtils.getApiDate("2022-10-07T00:42:53.811877Z");
         assertEquals(2022, date.get(ChronoField.YEAR));
         assertEquals(10, date.get(ChronoField.MONTH_OF_YEAR));
         assertEquals(7, date.get(ChronoField.DAY_OF_MONTH));
@@ -25,7 +26,7 @@ public class DateUtilsTest {
 
     @Test
     public void testSerialization() {
-        LocalDateTime time = Instant.ofEpochMilli(1667431825313L).atZone(ZoneOffset.UTC).toLocalDateTime();
+        ZonedDateTime time = Instant.ofEpochMilli(1667431825313L).atZone(ZoneOffset.UTC);
         String result = DateUtils.getApiDate(time);
         System.out.println(result);
         assertEquals("2022-11-02T23:30:25.313Z", result);


### PR DESCRIPTION
This pull request contains the following:

- Migrate `java.util.Date` to `java.time.ZonedDateTime`.
- Add convenience methods for `Instant` and `OffsetDateTime` (in addition to the standard `ZonedDateTime`) when creating requests.
- Create parent builder classes to reduce duplication between request classes and ensure consistency in parameters.
- Adds `pageAfterId` parameter to `VoiceActorsRequest` and `SpacedRepetitionSystemsRequest`.